### PR TITLE
Enhance Mermaid generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,19 @@ npx ts-node bin/undinespec.ts examples/sample.yaml
 Output:
 
 ```
-graph TD
-  GET__users --> res1["200: User[]"]
-  POST__users --> res2["201: User"]
+classDiagram
+class "/" {
+  <<Path>>
+}
+class "/users" {
+  <<Path>>
+
+  Query Parameters:
+    (none)
+
+  HTTP methods:
+    • GET(): User[]
+    • POST(): User
+}
+"/" --> "/users"
 ```

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,33 +1,117 @@
 export function generateMermaid(spec: any): string {
-  const lines = ['graph TD'];
+  const lines: string[] = ['classDiagram'];
+  const root = spec.servers?.[0]?.url || '/';
+  lines.push(`class "${root}" {`);
+  lines.push('  <<Path>>');
+  lines.push('}');
+
+  const classBlocks: string[] = [];
+  const relations: string[] = [];
+
   const paths = spec.paths || {};
-  let counter = 1;
-  for (const [path, methods] of Object.entries<any>(paths)) {
-    for (const [method, info] of Object.entries<any>(methods)) {
-      const responses = info.responses || {};
-      const status = Object.keys(responses)[0];
-      const res = responses[status] || {};
-      let label = status;
-      const schema = res.content?.['application/json']?.schema;
-      if (schema) {
-        label += ': ' + schemaToString(schema);
-      } else if (res.description) {
-        label += ': ' + res.description;
-      }
-      const nodeId = `res${counter++}`;
-      const from = `${method.toUpperCase()}_${path.replace(/[^a-zA-Z0-9]/g, '_')}`;
-      lines.push(`  ${from} --> ${nodeId}["${label}"]`);
+  const sortedPaths = Object.keys(paths).sort();
+
+  for (const path of sortedPaths) {
+    const pathItem: any = paths[path];
+    classBlocks.push(buildClassBlock(path, pathItem));
+    const parent = findParentPath(path, sortedPaths);
+    if (parent) {
+      relations.push(`"${parent}" --> "${path}"`);
+    } else {
+      relations.push(`"${root}" --> "${path}"`);
     }
   }
+
+  return lines.concat(classBlocks).concat(relations).join('\n');
+}
+
+function buildClassBlock(path: string, pathItem: any): string {
+  const lines: string[] = [];
+  lines.push(`class "${path}" {`);
+  lines.push('  <<Path>>');
+  lines.push('');
+  lines.push('  Query Parameters:');
+  const params = collectQueryParams(pathItem);
+  if (params.length === 0) {
+    lines.push('    (none)');
+  } else {
+    for (const p of params) {
+      const name = p.required
+        ? `<span style=\"color:red\">${p.name}</span>`
+        : p.name;
+      const type = schemaToString(p.schema);
+      lines.push(`    • ${name}: ${type}`);
+    }
+  }
+  lines.push('');
+  lines.push('  HTTP methods:');
+  for (const [method, op] of Object.entries<any>(pathItem)) {
+    if (!isHttpMethod(method)) continue;
+    const reqType = getRequestType(op);
+    const resType = getResponseType(op);
+    let line = `    • ${method.toUpperCase()}(`;
+    line += reqType ? reqType : '';
+    line += ')';
+    if (resType) line += `: ${resType}`;
+    lines.push(line);
+  }
+  lines.push('}');
   return lines.join('\n');
+}
+
+function collectQueryParams(pathItem: any): any[] {
+  const allParams = new Map<string, any>();
+  const addParam = (p: any) => {
+    if (p.in === 'query') {
+      allParams.set(p.name, p);
+    }
+  };
+  for (const p of pathItem.parameters || []) addParam(p);
+  for (const [method, op] of Object.entries<any>(pathItem)) {
+    if (!isHttpMethod(method)) continue;
+    for (const p of op.parameters || []) addParam(p);
+  }
+  return Array.from(allParams.values());
+}
+
+function getRequestType(op: any): string | '' {
+  const rb = op.requestBody;
+  const schema = rb?.content?.['application/json']?.schema;
+  return schema ? schemaToString(schema) : '';
+}
+
+function getResponseType(op: any): string | '' {
+  const res = op.responses || {};
+  const status = Object.keys(res)
+    .filter((s) => /^2/.test(s))
+    .sort()[0];
+  const chosen = status ? res[status] : undefined;
+  const schema = chosen?.content?.['application/json']?.schema;
+  if (schema) return schemaToString(schema);
+  if (chosen?.description) return chosen.description;
+  return '';
+}
+
+function isHttpMethod(m: string): boolean {
+  return ['get', 'post', 'put', 'delete', 'patch', 'head', 'options', 'trace'].includes(m);
+}
+
+function findParentPath(path: string, sortedPaths: string[]): string | null {
+  const segments = path.split('/').filter(Boolean);
+  if (segments.length <= 1) return null;
+  segments.pop();
+  while (segments.length) {
+    const parent = '/' + segments.join('/');
+    if (sortedPaths.includes(parent)) return parent;
+    segments.pop();
+  }
+  return null;
 }
 
 function schemaToString(schema: any): string {
   if (!schema) return '';
   if (schema.$ref) return refToName(schema.$ref);
-  if (schema.type === 'array') {
-    return schemaToString(schema.items) + '[]';
-  }
+  if (schema.type === 'array') return schemaToString(schema.items) + '[]';
   if (schema.type) return schema.type;
   return '';
 }


### PR DESCRIPTION
## Summary
- implement class diagram generator for API paths
- update README example for new diagram format

## Testing
- `npm run build`
- `npx ts-node bin/undinespec.ts examples/sample.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6846ceb55e0c8322b05552e576e11110